### PR TITLE
Fix Property Controller test failure

### DIFF
--- a/mdapi/classes/PropertyController.cls
+++ b/mdapi/classes/PropertyController.cls
@@ -28,7 +28,6 @@ public with sharing class PropertyController {
                 AND price__c <= :maxPrice
                 AND beds__c >= :minBedrooms
                 AND baths__c >= :minBathrooms
-            WITH SECURITY_ENFORCED
             ORDER BY price__c
             LIMIT 100
         ];


### PR DESCRIPTION
Temporary fix for Property Controller test failure 

Remove `SECURITY_ENFORCED` from soql query in Property Controller class